### PR TITLE
Add 3 get<xxxx>Folio() meethods and tests to validate them.

### DIFF
--- a/src/TripRepo.js
+++ b/src/TripRepo.js
@@ -21,6 +21,24 @@ class TripRepo {
     let end = new Date( year + 1, 0, 0);
     return new TripRepo(this.data.filter(trip => time.isBetween(beg, trip.date, end)), null, false);
   }
+
+  getUpcomingFolio(date) {
+    return new TripRepo(this.data.filter(trip => time.isBefore(date, trip.date)), null, false);
+  }
+
+  getPastFolio(date) {
+    return new TripRepo(this.data.filter(trip => {
+      let endDate = time.daysFromDate(trip.date, trip.duration);
+      return time.isAfter(date, endDate);
+    }), null, false);
+  }
+
+  getCurrentFolio(date) {
+    return new TripRepo(this.data.filter(trip => {
+      let endDate = time.daysFromDate(trip.date, trip.duration);
+      return time.isBetween(trip.date, date, endDate);
+    }), null, false);
+  }
 }
 
 export default TripRepo;

--- a/test/TripRepo-test.js
+++ b/test/TripRepo-test.js
@@ -33,7 +33,7 @@ describe('TripRepo', () => {
 
   describe('getFolioByUser', () => {
 
-    it('should return a new TripRepo of all the trips that match a given userID', function() {
+    it('should return a new TripRepo of all the trips that match a given userID', () => {
 
       expect(repo.getFolioByUser(44)).to.deep.equal(new TripRepo(data, []));
       expect(repo.getFolioByUser(0)).to.deep.equal(new TripRepo([], []));
@@ -42,10 +42,52 @@ describe('TripRepo', () => {
 
   describe('getFolioByYear', () => {
 
-    it('should return a new TripRepo of all the trips that match a given userID', function() {
+    it('should return a new TripRepo of all the trips that match a given userID', () => {
 
       expect(repo.getFolioByYear(2019)).to.deep.equal(new TripRepo(data, []));
       expect(repo.getFolioByYear(0)).to.deep.equal(new TripRepo([], []));
+    });
+  });
+
+  describe.only('getPastFolio', () => {
+
+    it('should return a new TripRepo of all the trips that have ended already', () => {
+
+      let date = new Date(2019, 8, 25);
+      expect(repo.getPastFolio(date)).to.deep.equal(repo);
+
+      let bad = new Date(2019, 8, 24);
+      expect(repo.getPastFolio(bad)).to.deep.equal(new TripRepo([], []));
+    });
+  });
+
+  describe.only('getCurrentFolio', () => {
+
+    it('should return a new TripRepo of all the trips that have ended already', () => {
+
+      let beg = new Date(2019, 8, 16);
+      let middle = new Date(2019, 8, 20);
+      let end = new Date(2019, 8, 24);
+      expect(repo.getCurrentFolio(beg)).to.deep.equal(repo);
+      expect(repo.getCurrentFolio(middle)).to.deep.equal(repo);
+      expect(repo.getCurrentFolio(end)).to.deep.equal(repo);
+
+      let before = new Date(2019, 8, 15);
+      let after = new Date(2019, 8, 25);
+      expect(repo.getCurrentFolio(before)).to.deep.equal(new TripRepo([], []));
+      expect(repo.getCurrentFolio(after)).to.deep.equal(new TripRepo([], []));
+    });
+  });
+
+  describe.only('getUpcomingFolio', () => {
+
+    it('should return a new TripRepo of all the trips that have ended already', () => {
+
+      let date = new Date(2019, 8, 15);
+      expect(repo.getUpcomingFolio(date)).to.deep.equal(repo);
+
+      let bad = new Date(2019, 8, 16);
+      expect(repo.getUpcomingFolio(bad)).to.deep.equal(new TripRepo([], []));
     });
   });
 });


### PR DESCRIPTION
- [x] checked functionality of the webpage
- [ ] received help from a mentor/collaborator?

## Notes
* Added 3 very similar methods
  - getPastFolio returns a new TripRepo instance of all the trips that have already ended from the perspective of a given Date.
  - getCurrentFolio returns a new TripRepo instance of all the trips that have begun but not ended from the perspective of a given Date.
  - getUpcomingFolio returns a new TripRepo instance of all the trips that have not yet begun.

Added tests for each of them.


Problems:

Time logic is REALLY easy to get backwards LOL