### PR TITLE
Add getNewId method to TripRepo. Verify with tests.

### DIFF
--- a/src/TripRepo.js
+++ b/src/TripRepo.js
@@ -9,7 +9,9 @@ class TripRepo {
         trip.destination = destinations.find(dest => dest.id === trip.destinationID);
         return trip;
       });
+      this.data.sort((a, b) => a.localCompare(b));
     } else this.data = data;
+    this.countIDs();
   }
 
   getFolioByUser(id) {
@@ -38,6 +40,23 @@ class TripRepo {
       let endDate = time.daysFromDate(trip.date, trip.duration);
       return time.isBetween(trip.date, date, endDate);
     }), null, false);
+  }
+
+  getNewTripID() {
+    for(let i = 0; i < this.data.length; i++) {
+      let newIDLow = this.data[i].id - 1;
+      if (this.tripIDs[newIDLow] === undefined && newIDLow > 0) return newIDLow;
+      let newIDHigh = this.data[i].id + 1;
+      if (this.tripIDs[newIDHigh] === undefined) return newIDHigh;
+    }
+    throw 'Corrupted ID Inventory Object'
+  }
+
+  countIDs() {
+    this.tripIDs = this.data.reduce((memory, trip) => {
+      memory[trip.id] = trip;
+      return memory;
+    }, {})
   }
 }
 

--- a/test/TripRepo-test.js
+++ b/test/TripRepo-test.js
@@ -4,8 +4,9 @@ import Trip from '../src/Trip.js';
 import TripRepo from '../src/TripRepo.js';
 
 
-describe('TripRepo', () => {
+describe.only('TripRepo', () => {
   let data, repo, trip;
+
   beforeEach(() => {
     let tData = {
       "id": 1,
@@ -26,9 +27,13 @@ describe('TripRepo', () => {
 
   describe('Initialization', () => {
 
-    it('should store an data', () => {
+    it('should store an array of trips', () => {
       expect(repo.data).to.deep.equal(data);
     });
+
+    it('should store an Object that stores all TripIDs', () => {
+      expect(repo.tripIDs).to.deep.equal({1: trip})
+    })
   });
 
   describe('getFolioByUser', () => {
@@ -49,21 +54,21 @@ describe('TripRepo', () => {
     });
   });
 
-  describe.only('getPastFolio', () => {
+  describe('getPastFolio', () => {
 
     it('should return a new TripRepo of all the trips that have ended already', () => {
 
       let date = new Date(2019, 8, 25);
       expect(repo.getPastFolio(date)).to.deep.equal(repo);
 
-      let bad = new Date(2019, 8, 24);
-      expect(repo.getPastFolio(bad)).to.deep.equal(new TripRepo([], []));
+      let beforeEnd = new Date(2019, 8, 24);
+      expect(repo.getPastFolio(beforeEnd)).to.deep.equal(new TripRepo([], []));
     });
   });
 
-  describe.only('getCurrentFolio', () => {
+  describe('getCurrentFolio', () => {
 
-    it('should return a new TripRepo of all the trips that have ended already', () => {
+    it('should return a new TripRepo of all the trips that have begun but not ended yet', () => {
 
       let beg = new Date(2019, 8, 16);
       let middle = new Date(2019, 8, 20);
@@ -79,15 +84,23 @@ describe('TripRepo', () => {
     });
   });
 
-  describe.only('getUpcomingFolio', () => {
+  describe('getUpcomingFolio', () => {
 
-    it('should return a new TripRepo of all the trips that have ended already', () => {
+    it('should return a new TripRepo of all the trips that haven\'t started yet', () => {
 
       let date = new Date(2019, 8, 15);
       expect(repo.getUpcomingFolio(date)).to.deep.equal(repo);
 
-      let bad = new Date(2019, 8, 16);
-      expect(repo.getUpcomingFolio(bad)).to.deep.equal(new TripRepo([], []));
+      let alreadyStarted = new Date(2019, 8, 16);
+      expect(repo.getUpcomingFolio(alreadyStarted)).to.deep.equal(new TripRepo([], []));
+    });
+  });
+
+  describe('getNewTripID', () => {
+
+    it('should return a new, unused ID', () => {
+
+      expect(repo.getNewTripID()).to.equal(2);
     });
   });
 });


### PR DESCRIPTION
- [x] checked functionality of the webpage
- [ ] received help from a mentor/collaborator?

## Notes
* Added a method to find a currently unused ID number.
  - It does so by testing the current Trip data for gaps in their numbering. It will terminate once it finds an unused ID (eventually adding one to the highest ID)
  - To simplify the process, added ID inventory system to be created during construction

* Added a test to validate functionality
